### PR TITLE
Migrating from version 1.7.* to 1.8.* of getdown and adding support for max_concurrent_downloads

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,9 +88,14 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.threerings</groupId>
-			<artifactId>getdown</artifactId>
-			<version>1.7.1</version>
+			<groupId>com.threerings.getdown</groupId>
+			<artifactId>getdown-launcher</artifactId>
+			<version>1.8.2</version>
+		</dependency>
+		<dependency>
+			<groupId>com.threerings.getdown</groupId>
+			<artifactId>getdown-core</artifactId>
+			<version>1.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.shared</groupId>

--- a/src/main/java/org/icestuff/getdown/maven/AbstractGetdownMojo.java
+++ b/src/main/java/org/icestuff/getdown/maven/AbstractGetdownMojo.java
@@ -45,6 +45,16 @@ public abstract class AbstractGetdownMojo extends AbstractMojo {
 	@Parameter(defaultValue = "false")
 	protected boolean verbose;
 
+	/**
+	 * The maximum number of downloads allowed to happen at once.
+     * Defaults to the number of cores in your CPU - 1
+     * <p>
+     * If you're having issues, that you suspect are related to concurrency,
+     * setting this to 1 might help.
+	 */
+	@Parameter
+	protected Integer maxConcurrentDownloads;
+
 	@Parameter
 	protected UiConfig ui = new UiConfig();
 
@@ -63,7 +73,7 @@ public abstract class AbstractGetdownMojo extends AbstractMojo {
 	/**
 	 * Compile class-path elements used to search for the keystore (if kestore
 	 * location was prefixed by {@code classpath:}).
-	 * 
+	 *
 	 * @since 1.0-beta-4
 	 */
 	@Parameter(defaultValue = "${project.compileClasspathElements}", required = true, readonly = true)
@@ -198,6 +208,15 @@ public abstract class AbstractGetdownMojo extends AbstractMojo {
 		}
 	}
 
+
+	protected void writeMaxConcurrentDownloads(PrintWriter writer) {
+		if (maxConcurrentDownloads != null) {
+			writer.println();
+			writer.println("# The maximum number of downloads allowed to happen at the same time.");
+			writer.println(String.format("max_concurrent_downloads = %s", maxConcurrentDownloads));
+		}
+	}
+
 	protected String formatResource(String key, JavaDownload d) {
 		return formatResource(key, d, d.path);
 	}
@@ -248,13 +267,13 @@ public abstract class AbstractGetdownMojo extends AbstractMojo {
 	/**
 	 * Computes the path for a file relative to a given base, or fails if the only
 	 * shared directory is the root and the absolute form is better.
-	 * 
+	 *
 	 * @param base File that is the base for the result
 	 * @param name File to be "relativized"
 	 * @return the relative name
 	 * @throws IOException if files have no common sub-directories, i.e. at best
 	 *                     share the root prefix "/" or "C:\"
-	 * 
+	 *
 	 *                     http://stackoverflow.com/questions/204784/how-to-construct-a-
 	 *                     relative-path-in-java-from-two-absolute-paths-or-urls
 	 */
@@ -278,7 +297,7 @@ public abstract class AbstractGetdownMojo extends AbstractMojo {
 
 	/**
 	 * Log as info when verbose or info is enabled, as debug otherwise.
-	 * 
+	 *
 	 * @param msg the message to display
 	 */
 	protected void verboseLog(String msg) {

--- a/src/main/java/org/icestuff/getdown/maven/MakeApplet.java
+++ b/src/main/java/org/icestuff/getdown/maven/MakeApplet.java
@@ -57,7 +57,7 @@ public class MakeApplet extends AbstractGetdownMojo {
 
 	protected void copyGetdownClient() throws MojoExecutionException {
 		getLog().info("Copying client jar");
-		Artifact getdown = (Artifact) plugin.getArtifactMap().get("com.threerings:getdown");
+		Artifact getdown = (Artifact) plugin.getArtifactMap().get("com.threerings.getdown:getdown-launcher");
 		Util.copyFile(getdown.getFile(), getClientJarFile());
 	}
 

--- a/src/main/java/org/icestuff/getdown/maven/MakeStub.java
+++ b/src/main/java/org/icestuff/getdown/maven/MakeStub.java
@@ -65,6 +65,7 @@ public class MakeStub extends AbstractGetdownMojo {
 			writer.println();
 			writeJavaConfiguration(writer);
 			writeTrackingConfiguration(writer);
+			writeMaxConcurrentDownloads(writer);
 		} finally {
 			writer.close();
 		}

--- a/src/main/java/org/icestuff/getdown/maven/MakeStub.java
+++ b/src/main/java/org/icestuff/getdown/maven/MakeStub.java
@@ -47,7 +47,7 @@ public class MakeStub extends AbstractGetdownMojo {
 
 	protected void copyGetdownClient() throws MojoExecutionException {
 		getLog().info("Copying client jar");
-		Artifact getdown = (Artifact) plugin.getArtifactMap().get("com.threerings:getdown");
+		Artifact getdown = (Artifact) plugin.getArtifactMap().get("com.threerings.getdown:getdown-launcher");
 		Util.copyFile(getdown.getFile(), new File(workDirectory, "getdown.jar"));
 	}
 

--- a/src/main/java/org/icestuff/getdown/maven/MakeUpdatesMojo.java
+++ b/src/main/java/org/icestuff/getdown/maven/MakeUpdatesMojo.java
@@ -87,6 +87,16 @@ public class MakeUpdatesMojo extends AbstractGetdownMojo {
 	@Parameter(defaultValue = "false")
 	private boolean allowOffline;
 
+	/**
+	 * The maximum number of downloads allowed to happen at once.
+	 * Defaults to the number of cores in your CPU - 1
+	 * <p>
+	 * If you're having issues, that you suspect are related to concurrency,
+	 * setting this to 1 might help.
+	 */
+	@Parameter
+	private Integer maxConcurrentDownloads;
+
 	@Parameter
 	private String[] appargs;
 
@@ -265,6 +275,11 @@ public class MakeUpdatesMojo extends AbstractGetdownMojo {
 				}
 			}
 
+			if (maxConcurrentDownloads != null) {
+				writer.println();
+				writer.println("# The maximum number of downloads allowed to happen at the same time.");
+				writer.println(String.format("max_concurrent_downloads = %s", maxConcurrentDownloads));
+			}
 		} finally {
 			writer.close();
 		}


### PR DESCRIPTION
When migrating from version 1.7.* to 1.8.* of getdown, you need to account for the fact that getdown has been refactored into various
modules. For clarity on the subject, see https://github.com/threerings/getdown/wiki/Migrating-from-1.7-to-1.8

Updating to version 1.8.2 of getdown in the pom.
Copying the correct artifact: 'com.threerings.getdown:getdown-launcher' instead of 'com.threerings:getdown'