### PR TITLE
Fixes null Pointer Exception when libPath is not defined in POM

### DIFF
--- a/src/main/java/org/icestuff/getdown/maven/MakeUpdatesMojo.java
+++ b/src/main/java/org/icestuff/getdown/maven/MakeUpdatesMojo.java
@@ -224,7 +224,7 @@ public class MakeUpdatesMojo extends AbstractGetdownMojo {
 
 			for (Artifact s : packagedJnlpArtifacts) {
 				String name = "";
-				if (!libPath.equals("")) {
+				if (libPath != null && !libPath.equals("")) {
 					name = libPath + "/";
 				}
 				name += getDependencyFileBasename(s, outputJarVersions);


### PR DESCRIPTION
This is the fix for Null Pointer Exception thrown, when libPath property is not defined in POM. At this point of time libPath is an optional property.