### PR TITLE
Stub work dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ Most of this configuration maps to entries in the getdown.txt file as described 
 | appargs | None | List of **apparg** elements, each one an argument to pass to the *mainClass* when launched |
 | jvmargs | None | List of **jvmarg** elements, each one an argument to pass to the JVM when launched |
 | ignoreMissingMain | false | If the plugin is added to a project of type *pom*, it may fail to find the mainClass, although this won't necessarily prevent your app from running. Set this to true to ignore this error.|
-| workDirectory | ${project.build.directory}/getdown | Location where update files end up. |
+| workDirectory | ${project.build.directory}/getdown | Location where update/applet files end up. |
+| stubWorkDirectory | ${project.build.directory}/getdown-stub | Location where stub files end up. |
 | excludeTransitive | false | Whether to exclude transitive dependencies. | 
 | allowOffline | false | Whether the getdown launcher will allow offline usage. |
 | resources | None | List of **resource** elements, each one a path to an additional resource to include. |

--- a/src/main/java/org/icestuff/getdown/maven/MakeStub.java
+++ b/src/main/java/org/icestuff/getdown/maven/MakeStub.java
@@ -25,11 +25,11 @@ public class MakeStub extends AbstractGetdownMojo {
 	 * The directory in which files will be stored prior to processing.
 	 */
 	@Parameter(defaultValue = "${project.build.directory}/getdown-stub", required = true)
-	private File workDirectory;
+	private File stubWorkDirectory;
 
 	public void execute() throws MojoExecutionException {
-		getLog().debug("using work directory " + workDirectory);
-		Util.makeDirectoryIfNecessary(workDirectory);
+		getLog().debug("using work directory " + stubWorkDirectory);
+		Util.makeDirectoryIfNecessary(stubWorkDirectory);
 		try {
 			copyUIResources();
 			makeConfigFile();
@@ -42,18 +42,18 @@ public class MakeStub extends AbstractGetdownMojo {
 	}
 
 	protected File getWorkDirectory() {
-		return workDirectory;
+		return stubWorkDirectory;
 	}
 
 	protected void copyGetdownClient() throws MojoExecutionException {
 		getLog().info("Copying client jar");
-		Artifact getdown = (Artifact) plugin.getArtifactMap().get("com.threerings:getdown");
-		Util.copyFile(getdown.getFile(), new File(workDirectory, "getdown.jar"));
+        Artifact getdown = (Artifact) plugin.getArtifactMap().get("com.threerings:getdown");
+		Util.copyFile(getdown.getFile(), new File(stubWorkDirectory, "getdown.jar"));
 	}
 
 	protected void makeConfigFile() throws FileNotFoundException {
 		getLog().info("Making stub getdown.txt");
-		PrintWriter writer = new PrintWriter(new File(workDirectory, "getdown.txt"));
+		PrintWriter writer = new PrintWriter(new File(stubWorkDirectory, "getdown.txt"));
 		try {
 			writer.println("# The URL from which the client is downloaded");
 			writer.println(String.format("appbase = %s", appbase));


### PR DESCRIPTION
Creates new "stubWorkDirectory" property, where Stub goal will write to files. This way it will fix issue #12, where Updates and Stub goals overwrite same "getdown.txt" file.