### PR TITLE
New groupId

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This plugin is available on Maven Central, so simply add the required plugin con
 
 ```
 	<plugin>
-		<groupId>org.icestuff</groupId>
+		<groupId>io.github.rockfireredmoon</groupId>
 		<artifactId>getdown-maven-plugin</artifactId>
 		<version>0.9.1</version>
 		<executions>


### PR DESCRIPTION
Correct me if I'm wrong, but the group ID appears to have changed. Using this new group ID works for me when using version 0.9.1, when the other group ID did not.